### PR TITLE
Trim password from given source

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -45,7 +45,7 @@ busNameParser = strOption
   )
 
 githubTokenAuthParser :: Parser (IO GH.Auth)
-githubTokenAuthParser = fmap (GH.OAuth . BS.pack) <$>
+githubTokenAuthParser = fmap (GH.OAuth . BS.pack . T.unpack . T.strip . T.pack) <$>
   (passGetMain <$> strOption
   (  long "github-token-pass"
   <> metavar "TOKEN-NAME"


### PR DESCRIPTION
Running a command with command runner leaves a newline at the end,
which shouldn't be included in the password value.

Hopefully passwords and tokens never looks like " foo" or "foo\n" or
"foo " and we corrupt em by trimming.