### PR TITLE
Attach authorization token on view one specific notification

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ library:
     - github
     - hslogger
     - http-conduit
+    - http-types
     - process
     - regex-compat
     - status-notifier-item >= 0.3.0.0


### PR DESCRIPTION
It requires this to fetch the html_url for a private repository which requires an authentication token.