### PR TITLE
stack: Upgrade github library from 0.22 to 0.24

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - gi-dbusmenu-0.4.1
 - gi-gio-2.0.18
 - gi-glib-2.0.17
-- github-0.22
+- github-0.24
 - haskell-gi-0.21.2
 - haskell-gi-base-0.21.1
 - spool-0.1


### PR DESCRIPTION
Seems to be what is the dependency in https://github.com/IvanMalison/notifications-tray-icon/blob/master/package.yaml